### PR TITLE
Remove application link from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
         <!--TODO Insert Design Hub slogan on left side of page, Make buttons transparent below-->
         <div class="row value-props">
             <div class="twelve columns">
-                <!--<p><a class="button button-landing" href="https://docs.google.com/forms/d/1_Ww2tlPyzDSVggttQ1mjFWeGlqo-Vf6EtZr9RkQ3MX0/viewform">SUBSCRIBE</a></p>  
+                <!--<p><a class="button button-landing" href="https://docs.google.com/forms/d/1_Ww2tlPyzDSVggttQ1mjFWeGlqo-Vf6EtZr9RkQ3MX0/viewform">SUBSCRIBE</a></p>
                 <!-- <p><a class="button button-landing" href="https://www.dropbox.com/s/b75y9r6l6bh8jss/ProjectBoardApplication2015.doc?dl=0" target="_blank">FUND YOUR IDEAS</a></p> -->
             </div>
         </div>
@@ -31,7 +31,7 @@
                         {document.write("Good evening!");}
                         else  /* the hour is not between 0 and 24, so something is wrong */
                         {document.write("Hello!");}
-                    </script> 
+                    </script>
                     <i class="fa fa-rocket"></i></h2>
                 <p>Come stay warm with us at our Thursday evening workshops, now with pizza! 🍕</p>
                 <p></p>
@@ -49,7 +49,7 @@
             <p><a class="button button-primary" href="https://goo.gl/forms/2bJjfNpK9UfCT9K32"><i class="fa fa-pencil-square-o"></i> Anonymous DesignHub Feedback Form</a></p>
             <p><a class="button button-primary" href="https://docs.google.com/forms/d/1_Ww2tlPyzDSVggttQ1mjFWeGlqo-Vf6EtZr9RkQ3MX0/viewform"><i class="fa fa-pencil-square-o"></i> SUBSCRIBE TO THE EMAIL LIST</a></p>
 
-            <p><a class="button button-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSf5skOwFnsKIRoaV2dgB29TwScz69y9LpYWqcP0Kc5Jg8ME0Q/viewform"><i class="fa fa-pencil-square-o"></i> Design Team Applications</a></p>
+            <!-- <p><a class="button button-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSf5skOwFnsKIRoaV2dgB29TwScz69y9LpYWqcP0Kc5Jg8ME0Q/viewform"><i class="fa fa-pencil-square-o"></i> Design Team Applications</a></p> -->
 
         <!--<p><a class="button button-primary" href="mailto:htp2@pitt.edu"><i class="fa fa-pencil-square-o"></i> Do you have an idea for a project?</a></p>-->
 
@@ -127,14 +127,15 @@
             <div class="twelve columns" id="events">
                 <h3><i class="fa fa-calendar"></i> Upcoming Events</h3>
                 <ul>
-                    <li> 1/26 - Second Robotics workshop - build 🤖</li>
+                    <li> 8/31 - First Meeting 🍕🍦!</li>
+                    <!-- <li> 1/26 - Second Robotics workshop - build 🤖</li>
                     <li> 2/2 - Third Robotics workshop - terrain challenge ⛰️</li>
                     <li> 2/16 - Python 🐍</li>
                     <li> 2/23 - ANSYS ⚡</li>
                     <li> 3/2 - Fun with Matlab! </li>
                     <li> 3/16 - Internal Design Hub Expo</li>
                     <li> 3/23 - LabView </li>
-                    <li> 3/30 - IoT Workshop 🔌</li>
+                    <li> 3/30 - IoT Workshop 🔌</li> -->
                 </ul>
             </div>
 


### PR DESCRIPTION
We don't want the designhub application link on the landing page anymore. Also, updated the current opportunities section. 